### PR TITLE
build: dt_image: support prebuilt DT images

### DIFF
--- a/build/tasks/dt_image.mk
+++ b/build/tasks/dt_image.mk
@@ -3,7 +3,9 @@
 #----------------------------------------------------------------------
 ifeq ($(strip $(BOARD_CUSTOM_BOOTIMG_MK)),)
 ifeq ($(strip $(BOARD_KERNEL_SEPARATED_DT)),true)
-ifneq ($(strip $(BOARD_KERNEL_PREBUILT_DT)),true)
+INSTALLED_DTIMAGE_TARGET := $(PRODUCT_OUT)/dt.img
+
+ifeq ($(strip $(BOARD_KERNEL_PREBUILT_DT)),)
 
 ifeq ($(strip $(TARGET_CUSTOM_DTBTOOL)),)
 DTBTOOL_NAME := dtbToolCM
@@ -12,8 +14,6 @@ DTBTOOL_NAME := $(TARGET_CUSTOM_DTBTOOL)
 endif
 
 DTBTOOL := $(HOST_OUT_EXECUTABLES)/$(DTBTOOL_NAME)$(HOST_EXECUTABLE_SUFFIX)
-
-INSTALLED_DTIMAGE_TARGET := $(PRODUCT_OUT)/dt.img
 
 ifeq ($(strip $(TARGET_CUSTOM_DTBTOOL)),)
 # dtbToolCM will search subdirectories
@@ -47,12 +47,19 @@ ifeq ($(strip $(BOARD_KERNEL_LZ4C_DT)),true)
 endif
 	@echo "Made DT image: $@"
 
+else
+
+$(INSTALLED_DTIMAGE_TARGET) : $(BOARD_KERNEL_PREBUILT_DT) | $(ACP)
+	$(transform-prebuilt-to-target)
+
+endif # BOARD_KERNEL_PREBUILT_DT
+
 ALL_DEFAULT_INSTALLED_MODULES += $(INSTALLED_DTIMAGE_TARGET)
 ALL_MODULES.$(LOCAL_MODULE).INSTALLED += $(INSTALLED_DTIMAGE_TARGET)
 
 .PHONY: dtimage
 dtimage: $(INSTALLED_DTIMAGE_TARGET)
 
-endif
+
 endif
 endif


### PR DESCRIPTION
If for whatever reason we need a prebuilt DT image,
it has to end up in target files for the signing slave.
Change BOARD_KERNEL_PREBUILT_DT to hold the path of the
prebuilt DT image, if it's going to be used.

Change-Id: I8042d347d271da5c3963824777d399bbc4229aa9