### PR TITLE
Halium 7.1

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -28,7 +28,7 @@ endif
 
 ifneq ($(TARGET_BUILD_VARIANT),eng)
 # Enable ADB authentication
-ADDITIONAL_DEFAULT_PROPERTIES += ro.adb.secure=1
+ADDITIONAL_DEFAULT_PROPERTIES += ro.adb.secure=0
 endif
 
 # Backup Tool


### PR DESCRIPTION
Fixed the ADB Devices being unauthorized when booting recovery for the first time without having to merge in keys.