### PR TITLE
Revert "Disable the cm off mode charger"

### DIFF
--- a/config/BoardConfigCM.mk
+++ b/config/BoardConfigCM.mk
@@ -1,7 +1,7 @@
 # Charger
-#ifneq ($(WITH_CM_CHARGER),false)
-#    BOARD_HAL_STATIC_LIBRARIES := libhealthd.cm
-#endif
+ifneq ($(WITH_CM_CHARGER),false)
+    BOARD_HAL_STATIC_LIBRARIES := libhealthd.cm
+endif
 
 ifeq ($(BOARD_CACHEIMAGE_FILE_SYSTEM_TYPE),)
   ADDITIONAL_DEFAULT_PROPERTIES += \

--- a/config/common.mk
+++ b/config/common.mk
@@ -161,13 +161,13 @@ PRODUCT_PACKAGES += \
     zip
 
 # Custom off-mode charger
-#ifneq ($(WITH_CM_CHARGER),false)
-#PRODUCT_PACKAGES += \
-#    charger_res_images \
-#    cm_charger_res_images \
-#    font_log.png \
-#    libhealthd.cm
-#endif
+ifneq ($(WITH_CM_CHARGER),false)
+PRODUCT_PACKAGES += \
+    charger_res_images \
+    cm_charger_res_images \
+    font_log.png \
+    libhealthd.cm
+endif
 
 # ExFAT support
 WITH_EXFAT ?= true


### PR DESCRIPTION
By re-introduce the charger images, this fixes off-mode charging for
distros that use halium-boot or any initrd that supports boot-to-android
mode for charger, without having to add this target to every device
tree.

This reverts commit acf0d238dc44602272b8d9e1b3c986ed75bd6e0a.

Change-Id: Ia15cb37efb8a10ac7a91eb4ff138032d246834ce